### PR TITLE
Save hash to reduce IO stress

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![deny(warnings)]
 
 extern crate clap;
 extern crate crypto;
@@ -158,17 +159,33 @@ fn main() {
                         let file_name = url.path().replace("%20", " ");
                         let file = mirror.join(&file_name[1..]);
 
-                        let mut need_download = true;
-                        if let Some(sha256) = file_sha256(file.as_path()) {
-                            if sha256 == pkg_target[&format!("{}hash", prefix)].as_str().unwrap() {
-                                need_download = false;
-                            }
-                        }
+                        let hash_file = mirror.join(format!("{}.sha256", &file_name[1..]));
+                        let hash_file_cont = File::open(hash_file.clone()).ok().and_then(|mut f| {
+                            let mut cont = String::new();
+                            f.read_to_string(&mut cont).ok().map(|_| cont)
+                        });
+
+                        let hash_file_missing = hash_file_cont.is_none();
+                        let mut hash_file_cont = hash_file_cont.or_else(|| file_sha256(file.as_path()));
+
+                        let chksum_upstream = pkg_target[&format!("{}hash", prefix)].as_str().unwrap();
+
+                        let need_download = match hash_file_cont {
+                            Some(ref chksum) => chksum_upstream != chksum,
+                            None => true,
+                        };
 
                         if need_download {
-                            download(mirror_path, &file_name[1..]);
+                            download(mirror_path, &file_name[1..]).unwrap();
+                            hash_file_cont = file_sha256(file.as_path());
+                            assert_eq!(Some(chksum_upstream), hash_file_cont.as_ref().map(|s| s.as_str()));
                         } else {
                             println!("File {} already downloaded, skipping", file_name);
+                        }
+
+                        if need_download || hash_file_missing {
+                            File::create(hash_file).unwrap().write_all(hash_file_cont.unwrap().as_bytes()).unwrap();
+                            println!("Writing chksum for file {}", file_name);
                         }
 
                         pkg_target.insert(


### PR DESCRIPTION
Save a `.sha256` file along package files for cheaper integrity check.