### PR TITLE
Add --keep_unmirrored_targets_available to keep unmirrored targets available for proxy/redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Features
 1. Check if file is already downloaded and check its integrity by comparing sha256 checksum.
 2. Download and replace links in the manifest files.
 3. Use `--keep` to choose which compression format(s) to mirror (e.g. `--keep xz` or `--keep gz`; default is `xz` only). Unkept archives are removed from the served manifest and their already-mirrored files are deleted, saving disk space. rustup prefers `zst > xz > gz` when listed, so installs still work.
+4. Use `--keep-unmirrored-targets-available` to leave metadata for targets excluded by `--targets` unchanged while still skipping their component downloads. Without this flag, excluded targets are marked `available = false`.
 
 Example usage
 =====================================

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,6 +446,11 @@ struct Cli {
     #[arg(short, long, value_delimiter = ',', default_values_t = TARGETS.map(String::from))]
     targets: Vec<String>,
 
+    /// Keep unmirrored targets available in channel metadata. Their components
+    /// are still not downloaded and their metadata remains unchanged.
+    #[arg(long)]
+    keep_unmirrored_targets_available: bool,
+
     /// Upstream url to sync from
     #[arg(short = 'U', long, default_value_t = DEFAULT_UPSTREAM_URL.to_string())]
     upstream_url: String,
@@ -534,11 +539,13 @@ fn main() {
                 let pkg_target = pkg_target.as_table_mut().unwrap();
 
                 // if we don't want to download this target
-                // set available to false and do not download
-                // but we will keep this table in the toml, which is required for newer version of
-                // rustup
+                // do not download it. By default, mark it unavailable while
+                // retaining its table, which is required for newer rustup.
+                // Optionally leave its upstream metadata entirely unchanged.
                 if !(filter_targets.contains(target) || *target == "*") {
-                    *pkg_target.get_mut("available").unwrap() = toml::Value::Boolean(false);
+                    if !args.keep_unmirrored_targets_available {
+                        *pkg_target.get_mut("available").unwrap() = toml::Value::Boolean(false);
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
Used when unmirrored targets would be proxyed or redirected.